### PR TITLE
deploy documentation without out folder

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Upload Docs to branch
         uses: EndBug/add-and-commit@v9
         with:
-          add: ./out
+          add: ./out/*
           new_branch: documentation


### PR DESCRIPTION
fix that now uploads everything in out instead of the out folder raw